### PR TITLE
[WIP] make `pip index versions` no longer experimental

### DIFF
--- a/docs/html/cli/index.md
+++ b/docs/html/cli/index.md
@@ -37,6 +37,7 @@ pip_hash
 :caption: Package Index information
 
 pip_search
+pip_index
 ```
 
 ```{toctree}

--- a/docs/html/cli/pip_index.rst
+++ b/docs/html/cli/pip_index.rst
@@ -1,0 +1,55 @@
+.. _`pip index`:
+
+===========
+pip index
+===========
+
+
+
+Usage
+=====
+
+.. tab:: Unix/macOS
+
+   .. pip-command-usage:: index "python -m pip"
+
+.. tab:: Windows
+
+   .. pip-command-usage:: index "py -m pip"
+
+
+Description
+===========
+
+.. pip-command-description:: index
+
+
+
+Options
+=======
+
+.. pip-command-options:: index
+
+
+
+Examples
+========
+
+#. Search for "peppercorn" versions
+
+   .. tab:: Unix/macOS
+
+      .. code-block:: console
+
+         $ python -m pip index versions peppercorn
+         peppercorn (0.6)
+         Available versions: 0.6, 0.5, 0.4, 0.3, 0.2, 0.1
+
+
+   .. tab:: Windows
+
+      .. code-block:: console
+
+         C:\> py -m pip index peppercorn
+         peppercorn (0.6)
+         Available versions: 0.6, 0.5, 0.4, 0.3, 0.2, 0.1

--- a/docs/html/reference/pip_index.rst
+++ b/docs/html/reference/pip_index.rst
@@ -1,0 +1,11 @@
+:orphan:
+
+.. meta::
+
+  :http-equiv=refresh: 3; url=../../cli/pip_index/
+
+This page has moved
+===================
+
+You should be redirected automatically in 3 seconds. If that didn't
+work, here's a link: :doc:`../cli/pip_index`

--- a/docs/man/commands/index.rst
+++ b/docs/man/commands/index.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+===========
+pip-index
+===========
+
+Description
+***********
+
+.. pip-command-description:: index
+
+Usage
+*****
+
+.. pip-command-usage:: index
+
+Options
+*******
+
+.. pip-command-options:: index

--- a/news/13188.feature.rst
+++ b/news/13188.feature.rst
@@ -1,2 +1,1 @@
-Remove `experimental` warning from `pip index versions` command and
-add json output support.
+Remove ``experimental`` warning from ``pip index versions`` command.

--- a/news/13188.feature.rst
+++ b/news/13188.feature.rst
@@ -1,0 +1,2 @@
+Remove `experimental` warning from `pip index versions` command and
+add json output support.

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -50,12 +50,6 @@ class IndexCommand(IndexGroupCommand):
             "versions": self.get_available_package_versions,
         }
 
-        logger.warning(
-            "pip index is currently an experimental command. "
-            "It may be removed/changed in a future release "
-            "without prior warning."
-        )
-
         # Determine action
         if not args or args[0] not in handlers:
             logger.error(


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
