### PR TITLE
Provide structured JSON output for `pip index versions`

### DIFF
--- a/news/13194.feature.rst
+++ b/news/13194.feature.rst
@@ -1,0 +1,1 @@
+Add a structured `--json` output to `pip index versions`

--- a/news/13194.feature.rst
+++ b/news/13194.feature.rst
@@ -1,1 +1,1 @@
-Add a structured `--json` output to `pip index versions`
+Add a structured ``--json`` output to ``pip index versions``

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -887,6 +887,14 @@ pre: Callable[..., Option] = partial(
     "pip only finds stable versions.",
 )
 
+json: Callable[..., Option] = partial(
+    Option,
+    "--json",
+    action="store_true",
+    default=False,
+    help="Output data in a machine-readable JSON format.",
+)
+
 disable_pip_version_check: Callable[..., Option] = partial(
     Option,
     "--disable-pip-version-check",

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -147,7 +147,7 @@ class IndexCommand(IndexGroupCommand):
                 }
 
             if dist is not None:
-                structured_output["installed_version"] = dist.version
+                structured_output["installed_version"] = str(dist.version)
 
 
             write_output(json.dumps(structured_output))

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -3,7 +3,6 @@ import logging
 from optparse import Values
 from typing import Any, Iterable, List, Optional
 
-from pip._internal.metadata import get_default_environment
 from pip._vendor.packaging.version import Version
 
 from pip._internal.cli import cmdoptions
@@ -13,6 +12,7 @@ from pip._internal.commands.search import print_dist_installation_info
 from pip._internal.exceptions import CommandError, DistributionNotFound, PipError
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
+from pip._internal.metadata import get_default_environment
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
@@ -141,14 +141,13 @@ class IndexCommand(IndexGroupCommand):
             env = get_default_environment()
             dist = env.get_distribution(query)
             structured_output = {
-                    "name": query,
-                    "versions": formatted_versions,
-                    "latest": latest,
-                }
+                "name": query,
+                "versions": formatted_versions,
+                "latest": latest,
+            }
 
             if dist is not None:
                 structured_output["installed_version"] = str(dist.version)
-
 
             write_output(json.dumps(structured_output))
             return

--- a/tests/functional/test_index.py
+++ b/tests/functional/test_index.py
@@ -16,9 +16,13 @@ def test_json_structured_output(script: PipTestEnvironment) -> None:
     output = script.pip("index", "versions", "pip", "--json", allow_stderr_warning=True)
     structured_output = json.loads(output.stdout)
 
+    assert isinstance(structured_output, dict)
     assert "name" in structured_output
-    assert "versions" in structured_output
+    assert structured_output["name"] == "pip"
     assert "latest" in structured_output
+    assert isinstance(structured_output["latest"], str)
+    assert "versions" in structured_output
+    assert isinstance(structured_output["versions"], list)
     assert (
         "20.2.3, 20.2.2, 20.2.1, 20.2, 20.1.1, 20.1, 20.0.2"
         ", 20.0.1, 19.3.1, 19.3, 19.2.3, 19.2.2, 19.2.1, 19.2, 19.1.1"
@@ -30,7 +34,7 @@ def test_json_structured_output(script: PipTestEnvironment) -> None:
         "1.5.2, 1.5.1, 1.5, 1.4.1, 1.4, 1.3.1, 1.3, 1.2.1, 1.2, 1.1, 1.0.2,"
         " 1.0.1, 1.0, 0.8.3, 0.8.2, 0.8.1, 0.8, 0.7.2, 0.7.1, 0.7, 0.6.3, "
         "0.6.2, 0.6.1, 0.6, 0.5.1, 0.5, 0.4, 0.3.1, "
-        "0.3, 0.2.1, 0.2" in ", ".join(structured_output.get("versions"))
+        "0.3, 0.2.1, 0.2" in ", ".join(structured_output["versions"])
     )
 
 

--- a/tests/functional/test_index.py
+++ b/tests/functional/test_index.py
@@ -29,7 +29,7 @@ def test_json_structured_output(script: PipTestEnvironment) -> None:
         "1.5.2, 1.5.1, 1.5, 1.4.1, 1.4, 1.3.1, 1.3, 1.2.1, 1.2, 1.1, 1.0.2,"
         " 1.0.1, 1.0, 0.8.3, 0.8.2, 0.8.1, 0.8, 0.7.2, 0.7.1, 0.7, 0.6.3, "
         "0.6.2, 0.6.1, 0.6, 0.5.1, 0.5, 0.4, 0.3.1, "
-        "0.3, 0.2.1, 0.2" in structured_output.get("versions")
+        "0.3, 0.2.1, 0.2" in ", ".join(structured_output.get("versions"))
     )
 
 @pytest.mark.network

--- a/tests/functional/test_index.py
+++ b/tests/functional/test_index.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
@@ -5,6 +6,31 @@ from pip._internal.commands import create_command
 
 from tests.lib import PipTestEnvironment
 
+
+@pytest.mark.network
+def test_json_structured_output(script: PipTestEnvironment) -> None:
+    """
+    Test that --json flag returns structured output
+    """
+    output = script.pip("index", "versions", "pip", "--json", allow_stderr_warning=True)
+    structured_output = json.loads(output.stdout)
+
+    assert "name" in structured_output
+    assert "versions" in structured_output
+    assert "latest" in structured_output
+    assert (
+        "20.2.3, 20.2.2, 20.2.1, 20.2, 20.1.1, 20.1, 20.0.2"
+        ", 20.0.1, 19.3.1, 19.3, 19.2.3, 19.2.2, 19.2.1, 19.2, 19.1.1"
+        ", 19.1, 19.0.3, 19.0.2, 19.0.1, 19.0, 18.1, 18.0, 10.0.1, 10.0.0, "
+        "9.0.3, 9.0.2, 9.0.1, 9.0.0, 8.1.2, 8.1.1, "
+        "8.1.0, 8.0.3, 8.0.2, 8.0.1, 8.0.0, 7.1.2, 7.1.1, 7.1.0, 7.0.3, "
+        "7.0.2, 7.0.1, 7.0.0, 6.1.1, 6.1.0, 6.0.8, 6.0.7, 6.0.6, 6.0.5, "
+        "6.0.4, 6.0.3, 6.0.2, 6.0.1, 6.0, 1.5.6, 1.5.5, 1.5.4, 1.5.3, "
+        "1.5.2, 1.5.1, 1.5, 1.4.1, 1.4, 1.3.1, 1.3, 1.2.1, 1.2, 1.1, 1.0.2,"
+        " 1.0.1, 1.0, 0.8.3, 0.8.2, 0.8.1, 0.8, 0.7.2, 0.7.1, 0.7, 0.6.3, "
+        "0.6.2, 0.6.1, 0.6, 0.5.1, 0.5, 0.4, 0.3.1, "
+        "0.3, 0.2.1, 0.2" in structured_output.get("versions")
+    )
 
 @pytest.mark.network
 def test_list_all_versions_basic_search(script: PipTestEnvironment) -> None:

--- a/tests/functional/test_index.py
+++ b/tests/functional/test_index.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
@@ -31,6 +32,7 @@ def test_json_structured_output(script: PipTestEnvironment) -> None:
         "0.6.2, 0.6.1, 0.6, 0.5.1, 0.5, 0.4, 0.3.1, "
         "0.3, 0.2.1, 0.2" in ", ".join(structured_output.get("versions"))
     )
+
 
 @pytest.mark.network
 def test_list_all_versions_basic_search(script: PipTestEnvironment) -> None:


### PR DESCRIPTION
Usage:

```sh
❯ pip index versions build --json
{"name": "build", "versions": ["1.2.2.post1", "1.2.2", "1.2.1", "1.1.1", "1.0.3", "1.0.0", "0.10.0", "0.9.0", "0.8.0", "0.7.0", "0.6.0.post1", "0.5.1", "0.5.0", "0.4.0", "0.3.1.post1", "0.3.1", "0.3.0", "0.2.1", "0.2.0", "0.1.0", "0.0.4", "0.0.3.1", "0.0.2", "0.0.1"], "latest": "1.2.2.post1", "installed_version": "1.2.2.post1"}
```

which is properly formatted JSON - it prettifies to:

```json
{
  "name": "build",
  "versions": [
    "1.2.2.post1",
    "1.2.2",
    "1.2.1",
    "1.1.1",
    "1.0.3",
    "1.0.0",
    "0.10.0",
    "0.9.0",
    "0.8.0",
    "0.7.0",
    "0.6.0.post1",
    "0.5.1",
    "0.5.0",
    "0.4.0",
    "0.3.1.post1",
    "0.3.1",
    "0.3.0",
    "0.2.1",
    "0.2.0",
    "0.1.0",
    "0.0.4",
    "0.0.3.1",
    "0.0.2",
    "0.0.1"
  ],
  "latest": "1.2.2.post1",
  "installed_version": "1.2.2.post1"
}
```